### PR TITLE
Import ABC from collections.abc instead of collections for Python 3 compatibility

### DIFF
--- a/mat4py/loadmat.py
+++ b/mat4py/loadmat.py
@@ -11,7 +11,11 @@ import struct
 import sys
 import zlib
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
+
 from itertools import tee
 try:
     from itertools import izip

--- a/mat4py/savemat.py
+++ b/mat4py/savemat.py
@@ -12,7 +12,11 @@ import sys
 import time
 import zlib
 
-from collections import Sequence, Mapping
+try:
+    from collections.abc import Sequence, Mapping
+except ImportError:
+    from collections import Sequence, Mapping
+
 from itertools import chain, tee
 try:
     from itertools import izip


### PR DESCRIPTION
Fixes #4 